### PR TITLE
Add Sylvan.Data.Csv to the benchmarks

### DIFF
--- a/NCsvPerf.Test/NCsvPerf.Test.csproj
+++ b/NCsvPerf.Test/NCsvPerf.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Knapcode.NCsvPerf.Test</RootNamespace>
   </PropertyGroup>

--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -24,8 +24,7 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         [ParamsSource(nameof(LineCountSource))]
         public int LineCount { get; set; }
 
-        //public static IReadOnlyList<int> LineCountSource { get; } = new[] { 0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000 };
-        public static IReadOnlyList<int> LineCountSource { get; } = new[] { 100_000};
+        public static IReadOnlyList<int> LineCountSource { get; } = new[] { 0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000 };
 
         [GlobalSetup]
         public void GlobalSetup()

--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -4,6 +4,7 @@ using System.IO;
 
 namespace Knapcode.NCsvPerf.CsvReadable.TestCases
 {
+    [MemoryDiagnoser]
     public class PackageAssetsSuite
     {
         private byte[] _bytes;
@@ -23,7 +24,8 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         [ParamsSource(nameof(LineCountSource))]
         public int LineCount { get; set; }
 
-        public static IReadOnlyList<int> LineCountSource { get; } = new[] { 0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000 };
+        //public static IReadOnlyList<int> LineCountSource { get; } = new[] { 0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000 };
+        public static IReadOnlyList<int> LineCountSource { get; } = new[] { 100_000};
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -36,6 +38,10 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             using (var memoryStream = new MemoryStream(_bytes, writable: false))
             {
                 var result = reader.GetRecords<PackageAsset>(memoryStream);
+                if(result.Count != LineCount)
+                {
+                    throw new System.Exception("Failed to produce correct number of rows");
+                }
                 if (_saveResult)
                 {
                     LatestResult = result;
@@ -43,7 +49,7 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             }
         }
 
-        [Benchmark]
+        [Benchmark(Baseline = true)]
         public void CsvHelperCsvReader()
         {
             Execute(new CsvHelper(ActivationMethod.ILEmit));
@@ -107,6 +113,12 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         public void TinyCsvReader()
         {
             Execute(new TinyCsvParser(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
+        public void SylvanCsvReader()
+        {
+            Execute(new SylvanCsv(ActivationMethod.ILEmit));
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/SylvanCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/SylvanCsv.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using Sylvan;
 using Sylvan.Data.Csv;
 
 namespace Knapcode.NCsvPerf.CsvReadable
 {
     /// <summary>
-    /// Package: https://www.nuget.org/packages/NReco.Csv/
-    /// Source: https://github.com/nreco/csv
+    /// Package: https://www.nuget.org/packages/Sylvan.Data.Csv/
+    /// Source: https://github.com/MarkPflug/Sylvan
     /// </summary>
     public class SylvanCsv : ICsvReader
     {
@@ -21,10 +22,18 @@ namespace Knapcode.NCsvPerf.CsvReadable
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();
+            // 64 should fully cover the values in the dataset.
+            var stringPool = new StringPool(64); 
 
             using (var reader = new StreamReader(stream))
             {
-                var csvReader = CsvDataReader.Create(reader, new CsvDataReaderOptions() { HasHeaders = false, BufferSize = 0x10000 });
+                var opts = new CsvDataReaderOptions() {
+                    HasHeaders = false,
+                    BufferSize = 0x10000,
+                    StringFactory = stringPool.GetString
+                };
+
+                var csvReader = CsvDataReader.Create(reader, opts);
                 while (csvReader.Read())
                 {
                     var record = activate();

--- a/NCsvPerf/CsvReadable/Implementations/SylvanCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/SylvanCsv.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Sylvan.Data.Csv;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/NReco.Csv/
+    /// Source: https://github.com/nreco/csv
+    /// </summary>
+    public class SylvanCsv : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public SylvanCsv(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+
+            using (var reader = new StreamReader(stream))
+            {
+                var csvReader = CsvDataReader.Create(reader, new CsvDataReaderOptions() { HasHeaders = false });
+                while (csvReader.Read())
+                {
+                    var record = activate();
+                    record.Read(i => csvReader.GetString(i));
+                    allRecords.Add(record);
+                }
+            }
+
+            return allRecords;
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/Implementations/SylvanCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/SylvanCsv.cs
@@ -24,7 +24,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
 
             using (var reader = new StreamReader(stream))
             {
-                var csvReader = CsvDataReader.Create(reader, new CsvDataReaderOptions() { HasHeaders = false });
+                var csvReader = CsvDataReader.Create(reader, new CsvDataReaderOptions() { HasHeaders = false, BufferSize = 0x10000 });
                 while (csvReader.Read())
                 {
                     var record = activate();

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="mgholam.fastCSV" Version="2.0.9" />
     <PackageReference Include="NReco.Csv" Version="1.0.0" />
     <PackageReference Include="ServiceStack.Text" Version="5.10.2" />
+    <PackageReference Include="Sylvan.Common" Version="0.2.0" />
     <PackageReference Include="Sylvan.Data.Csv" Version="0.8.2" />
     <PackageReference Include="TinyCsvParser" Version="2.6.0" />
   </ItemGroup>

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Knapcode.NCsvPerf</RootNamespace>
   </PropertyGroup>
 
@@ -16,6 +16,7 @@
     <PackageReference Include="mgholam.fastCSV" Version="2.0.8" />
     <PackageReference Include="NReco.Csv" Version="1.0.0" />
     <PackageReference Include="ServiceStack.Text" Version="5.10.2" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="0.8.1" />
     <PackageReference Include="TinyCsvParser" Version="2.6.0" />
   </ItemGroup>
 

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -8,15 +8,15 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Csv" Version="1.0.58" />
-    <PackageReference Include="CsvHelper" Version="18.0.0" />
+    <PackageReference Include="Csv" Version="2.0.62" />
+    <PackageReference Include="CsvHelper" Version="19.0.0" />
     <PackageReference Include="CsvTextFieldParser" Version="1.2.1" />
     <PackageReference Include="FastCsvParser" Version="1.1.1" />
     <PackageReference Include="LumenWorksCsvReader" Version="4.0.0" />
-    <PackageReference Include="mgholam.fastCSV" Version="2.0.8" />
+    <PackageReference Include="mgholam.fastCSV" Version="2.0.9" />
     <PackageReference Include="NReco.Csv" Version="1.0.0" />
     <PackageReference Include="ServiceStack.Text" Version="5.10.2" />
-    <PackageReference Include="Sylvan.Data.Csv" Version="0.8.1" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="0.8.2" />
     <PackageReference Include="TinyCsvParser" Version="2.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hello Joel.

I've also also put together some [CsvBenchmarks](https://github.com/MarkPflug/CsvBenchmarks/blob/main/docs/CsvReaderBenchmarks.md) for .NET. I've been claiming that my library, Sylvan.Data.Csv, is the fastest, so I was curious how I stacked up with your dataset. This PR adds my library to your benchmarks. I was aware of NReco and how fast it was, but I hadn't seen this mgholam.FastCsv library. I'll add it to my benchmarks too. I'm also adding the FluentCsv to mine (not yet on github).

