### PR TITLE
Increase string pool limit

### DIFF
--- a/NCsvPerf/CsvReadable/Implementations/Sylvan_Data_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Sylvan_Data_Csv.cs
@@ -22,8 +22,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();
-            // 64 should fully cover the values in the dataset.
-            var stringPool = new StringPool(64); 
+            var stringPool = new StringPool(128); 
 
             using (var reader = new StreamReader(stream))
             {

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="ServiceStack.Text" Version="5.10.4" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="2.4.3" />
     <PackageReference Include="Sylvan.Common" Version="0.2.0" />
-    <PackageReference Include="Sylvan.Data.Csv" Version="0.9.0" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="0.9.1" />
     <PackageReference Include="TinyCsvParser" Version="2.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Wow, lots of action in the CSV Battle Royale recently!

Looks like Cursively took the crown by using my own tricks against me. I think that I can take it back by increasing the string pool limit... at least it does on my machine. I had landed on 64 just by eye-balling the contents of the test csv, but it turns out that there are some larger strings in there too.

Are you regretting putting these benchmarks together yet?! I'm sure its a pain to be rerunning these and updating the blog, so don't bother unless/until some other interesting contenders appear.