### PR TITLE
Fix clojure instantiation in loop

### DIFF
--- a/NCsvPerf/CsvReadable/Implementations/RecordParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/RecordParser.cs
@@ -26,12 +26,18 @@ namespace Knapcode.NCsvPerf.CsvReadable
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var reader = BuildReader(activate);
+
+            string[] fields = null;
+            // closure over fields only allocated once
+            Func<int, string> getFields = i => fields[i];
+
             var result = ProcessStream<T>(stream, spanLine =>
             {
-                var fields = reader.Parse(spanLine);
+                fields = reader.Parse(spanLine);
+
                 var record = activate();
 
-                record.Read(i => fields[i]);
+                record.Read(getFields);
 
                 return record;
             });


### PR DESCRIPTION
This was pointed out by @MarkPflug in [comment](https://github.com/joelverhagen/NCsvPerf/pull/30#discussion_r667414826) of #30. 

This fix improved allocations from 345 MB to 261 MB (~ 24% less).  
Performance was a bit improved too, since less instructions of instantiations are performed.

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.18363.1440 (1909/November2019Update/19H2)
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET SDK=5.0.104
  [Host]     : .NET 5.0.4 (5.0.421.11614), X64 RyuJIT
  DefaultJob : .NET 5.0.4 (5.0.421.11614), X64 RyuJIT


```
|       Method | LineCount |    Mean |    Error |   StdDev |  Median |      Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|------------- |---------- |--------:|---------:|---------:|--------:|-----------:|-----------:|----------:|----------:|
| RecordParser |   1000000 | 2.745 s | 0.0541 s | 0.0888 s | 2.704 s | 43000.0000 | 16000.0000 | 3000.0000 |    261 MB |
|    CsvHelper |   1000000 | 3.802 s | 0.1026 s | 0.2910 s | 3.815 s | 43000.0000 | 16000.0000 | 3000.0000 |    261 MB |
|    Cursively |   1000000 | 2.750 s | 0.0502 s | 0.0420 s | 2.765 s | 58000.0000 | 21000.0000 | 3000.0000 |    345 MB |
