### PR TITLE
Add more libraries

### DIFF
--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -49,11 +49,11 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
                 }
             }
         }
-
+                
         [Benchmark]
-        public void RecordParser()
+        public void AngaraTable()
         {
-            Execute(new RecordParser(ActivationMethod.ILEmit));
+            Execute(new AngaraTable(ActivationMethod.ILEmit));
         }
 
         [Benchmark]
@@ -111,9 +111,21 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         }
 
         [Benchmark]
+        public void DSV()
+        {
+            Execute(new DSV(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
         public void FastCsvParser()
         {
             Execute(new FastCsvParser(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
+        public void FileHelpers()
+        {
+            Execute(new FileHelpers(ActivationMethod.ILEmit));
         }
 
         [Benchmark]
@@ -135,6 +147,12 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         }
 
         [Benchmark]
+        public void KB_Csv()
+        {
+            Execute(new KB_Csv(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
         public void LinqToCsv()
         {
             Execute(new LinqToCsv(ActivationMethod.ILEmit));
@@ -151,6 +169,18 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         {
             Execute(new mgholam_fastCSV());
         }
+        
+        [Benchmark]
+        public void MicrosoftML()
+        {
+            Execute(new MicrosoftML(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
+        public void MicrosoftDataAnalysis()
+        {
+            Execute(new MicrosoftDataAnalysis(ActivationMethod.ILEmit));
+        }
 
         [Benchmark]
         public void Microsoft_VisualBasic_FileIO_TextFieldParser()
@@ -162,6 +192,21 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         public void NReco_Csv()
         {
             Execute(new NReco_Csv(ActivationMethod.ILEmit));
+        }
+
+        //[Benchmark] 
+        // this library currently fails correctness tests
+        // it seems to skip empty columns, and I see no way to 
+        // access the column index.
+        public void Open_Text_CSV()
+        {
+            Execute(new Open_Text_CSV(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
+        public void RecordParser()
+        {
+            Execute(new RecordParser(ActivationMethod.ILEmit));
         }
 
         [Benchmark]

--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -200,10 +200,7 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             Execute(new NReco_Csv(ActivationMethod.ILEmit));
         }
 
-        //[Benchmark]
-        // this library currently fails correctness tests
-        // it seems to skip empty columns, and I see no way to
-        // access the column index.
+        [Benchmark]
         public void Open_Text_CSV()
         {
             Execute(new Open_Text_CSV(ActivationMethod.ILEmit));

--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -49,11 +49,17 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
                 }
             }
         }
-                
+
         [Benchmark]
         public void AngaraTable()
         {
             Execute(new AngaraTable(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
+        public void Cesil()
+        {
+            Execute(new Cesil(ActivationMethod.ILEmit));
         }
 
         [Benchmark]
@@ -169,7 +175,7 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         {
             Execute(new mgholam_fastCSV());
         }
-        
+
         [Benchmark]
         public void MicrosoftML()
         {
@@ -194,9 +200,9 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             Execute(new NReco_Csv(ActivationMethod.ILEmit));
         }
 
-        //[Benchmark] 
+        //[Benchmark]
         // this library currently fails correctness tests
-        // it seems to skip empty columns, and I see no way to 
+        // it seems to skip empty columns, and I see no way to
         // access the column index.
         public void Open_Text_CSV()
         {
@@ -244,6 +250,7 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         {
             Execute(new TinyCsvParser(ActivationMethod.ILEmit));
         }
+
         [Benchmark]
         public void TxtCsvHelper()
         {

--- a/NCsvPerf/CsvReadable/Implementations/AngaraTable.cs
+++ b/NCsvPerf/CsvReadable/Implementations/AngaraTable.cs
@@ -1,0 +1,52 @@
+﻿using Angara.Data;
+using Angara.Data.DelimitedFile;
+using Microsoft.FSharp.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/Angara.Table
+    /// Source: https://github.com/microsoft/Angara.Table
+    /// </summary>
+    public class AngaraTable : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public AngaraTable(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        class Types : FSharpFunc<Tuple<int, string>, FSharpOption<Type>>
+        {
+            static readonly FSharpOption<Type> StringType = new FSharpOption<Type>(typeof(string));
+
+            public override FSharpOption<Type> Invoke(Tuple<int, string> func)
+            {
+                return StringType;
+            }
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+
+            using (var reader = new StreamReader(stream))
+            {
+                var cols = new FSharpOption<FSharpFunc<Tuple<int, string>, FSharpOption<Type>>>(new Types());
+                var table = Table.Load(reader, new ReadSettings(Delimiter.Comma, false, false, FSharpOption<int>.None, cols));
+                var allRecords = new List<T>(table.RowsCount);
+                for (int r = 0; r < table.RowsCount; r++)
+                {
+                    var item = activate();
+                    item.Read(i => table[i].Rows.Item(r).AsString);
+                    allRecords.Add(item);
+                }
+                return allRecords;
+            }
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/Implementations/Cesil.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Cesil.cs
@@ -1,0 +1,47 @@
+﻿using Cesil;
+using Knapcode.NCsvPerf.CsvReadable.TestCases;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/Cesil/
+    /// Source: https://github.com/kevin-montrose/cesil
+    /// </summary>
+    public class Cesil : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public Cesil(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            // specialize for T == PackageAsset
+            return GetAssets(stream) as List<T>;
+        }
+
+        public List<PackageAsset> GetAssets(MemoryStream stream) {
+            var allRecords = new List<PackageAsset>();
+            using (var reader = new StreamReader(stream))
+            {
+                var config = Configuration.For<PackageAsset>();
+                var csv = config.CreateReader(reader);
+                foreach (var row in csv.EnumerateAll())
+                {
+                    allRecords.Add(row);
+                    // for some reason this final field is null for certain records
+                    // which was causing tests to fail
+                    if (row.PlatformVersion == null)
+                        row.PlatformVersion = "";
+                }
+            }
+
+            return allRecords;
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/Implementations/DSV.cs
+++ b/NCsvPerf/CsvReadable/Implementations/DSV.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Dsv;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/Dsv
+    /// Source: https://github.com/atifaziz/Dsv
+    /// </summary>
+    public class DSV : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public DSV(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+
+            using (var reader = new StreamReader(stream))
+            {
+                var lines = EnumerateLines(reader);
+                foreach (var row in lines.ParseCsv())
+                {
+                    var record = activate();
+                    record.Read(i => row[i]);
+                    allRecords.Add(record);
+                }
+            }
+
+            return allRecords;
+        }
+
+        static IEnumerable<string> EnumerateLines(TextReader r)
+        {
+            string line;
+            while ((line = r.ReadLine()) != null)
+            {
+                yield return line;
+            }
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/FileHelpers/
+    /// Source: https://github.com/MarcosMeli/FileHelpers
+    /// </summary>
+    public class FileHelpers : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public FileHelpers(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+
+            using (var reader = new StreamReader(stream))
+            {
+                // bit of a hack, since this only works for T == PackageAsset
+                var engine = new global::FileHelpers.FileHelperAsyncEngine<PackageAssetData>();
+                using (engine.BeginReadStream(reader))
+                {
+                    foreach (var item in engine)
+                    {
+                        // it seems like it would be slow to create a PackageAssetData
+                        // and then subsequently copy all the fields to a PackageAsset
+                        // but this approach is actually faster than having FileHelpers
+                        // bind directly to the PackageAsset.
+                        var record = activate();
+                        record.Read(i => item.GetString(i));
+                        allRecords.Add(record);
+                    }
+                }
+            }
+
+            return allRecords;
+        }
+        [global::FileHelpers.DelimitedRecord(",")]
+        public class PackageAssetData
+        {
+            public string ScanId { get; set; }
+            public string ScanTimestamp { get; set; }
+            public string Id { get; set; }
+            public string Version { get; set; }
+            public string Created { get; set; }
+            public string ResultType { get; set; }
+
+            public string PatternSet { get; set; }
+            public string PropertyAnyValue { get; set; }
+            public string PropertyCodeLanguage { get; set; }
+            public string PropertyTargetFrameworkMoniker { get; set; }
+            public string PropertyLocale { get; set; }
+            public string PropertyManagedAssembly { get; set; }
+            public string PropertyMSBuild { get; set; }
+            public string PropertyRuntimeIdentifier { get; set; }
+            public string PropertySatelliteAssembly { get; set; }
+
+            public string Path { get; set; }
+            public string FileName { get; set; }
+            public string FileExtension { get; set; }
+            public string TopLevelFolder { get; set; }
+
+            public string RoundTripTargetFrameworkMoniker { get; set; }
+            public string FrameworkName { get; set; }
+            public string FrameworkVersion { get; set; }
+            public string FrameworkProfile { get; set; }
+            public string PlatformName { get; set; }
+            public string PlatformVersion { get; set; }
+
+            public string GetString(int i)
+            {
+                switch (i)
+                {
+                    case 0: return ScanId;
+                    case 1: return ScanTimestamp;
+                    case 2: return Id;
+                    case 3: return Version;
+                    case 4: return Created;
+                    case 5: return ResultType;
+                    case 6: return PatternSet;
+                    case 7: return PropertyAnyValue;
+                    case 8: return PropertyCodeLanguage;
+                    case 9: return PropertyTargetFrameworkMoniker;
+                    case 10: return PropertyLocale;
+                    case 11: return PropertyManagedAssembly;
+                    case 12: return PropertyMSBuild;
+                    case 13: return PropertyRuntimeIdentifier;
+                    case 14: return PropertySatelliteAssembly;
+                    case 15: return Path;
+                    case 16: return FileName;
+                    case 17: return FileExtension;
+                    case 18: return TopLevelFolder;
+                    case 19: return RoundTripTargetFrameworkMoniker;
+                    case 20: return FrameworkName;
+                    case 21: return FrameworkVersion;
+                    case 22: return FrameworkProfile;
+                    case 23: return PlatformName;
+                    case 24: return PlatformVersion;
+                }
+                throw new ArgumentOutOfRangeException(nameof(i));
+            }
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/Implementations/MicrosoftDataAnalsysis.cs
+++ b/NCsvPerf/CsvReadable/Implementations/MicrosoftDataAnalsysis.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Data.Analysis;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/Microsoft.Data.Analysis/
+    /// Source: https://github.com/dotnet/MachineLearning
+    /// </summary>
+    public class MicrosoftDataAnalysis : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        static Type[] types = Enumerable.Range(0, 25).Select(i => typeof(string)).ToArray();
+
+        public MicrosoftDataAnalysis(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+
+            // This only works for data with exactly 25 columns.
+            // You must either provide the column types, or the types will be
+            // guessed. Can't allow guessing, because the round-trip back to string doesn't preserve the exact text.
+            // Must know the number of columns to provide the schema, so this isn't general-purpose for any <T>.
+            DataFrame frame;
+            try
+            {
+                frame = DataFrame.LoadCsv(stream, header: false, guessRows: 0, dataTypes: types);
+            } 
+            catch(FormatException e)
+            {
+                if (e.Message == "Empty file")
+                    return allRecords;
+                throw;
+            }
+            foreach (var row in frame.Rows)
+            {
+                var record = activate();
+                record.Read(i => row[i].ToString());
+                allRecords.Add(record);
+            }
+
+            return allRecords;
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/Implementations/MicrosoftML.cs
+++ b/NCsvPerf/CsvReadable/Implementations/MicrosoftML.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.ML;
+using Microsoft.ML.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/Microsoft.ML
+    /// Source: https://github.com/dotnet/machinelearning
+    /// </summary>
+    public class MicrosoftML : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public MicrosoftML(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            // this library only allows loading from a file.
+            // so write to a local file, use the length of the memory stream
+            // to write to a different file based on the input data
+            // this will be executed during the first "warmup" run
+            var file = "data" + stream.Length + ".csv";
+
+            if (!File.Exists(file))
+            {
+                using var data = File.Create(file);
+                stream.CopyTo(data);
+            }
+
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+            var mlc = new MLContext();
+
+            using (var reader = new StreamReader(stream))
+            {
+                var schema = new TextLoader.Column[25];
+                for (int i = 0; i < schema.Length; i++)
+                {
+                    schema[i] = new TextLoader.Column("" + i, DataKind.String, i);
+                }
+
+                var opts = new TextLoader.Options() { HasHeader = false, Separators = new[] { ',' }, Columns = schema };
+                var l = mlc.Data.LoadFromTextFile(file, opts);
+                var rc = l.GetRowCursor(l.Schema);
+                var cols = l.Schema.ToArray();
+                var getters = cols.Select(c => rc.GetGetter<ReadOnlyMemory<char>>(c)).ToArray();
+                while (rc.MoveNext())
+                {
+                    var record = activate();
+                    record.Read(i => { ReadOnlyMemory<char> s = null; getters[i](ref s); return s.ToString(); });
+                    allRecords.Add(record);
+                }
+            }
+
+            return allRecords;
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/Implementations/OpenTextCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/OpenTextCsv.cs
@@ -1,0 +1,41 @@
+﻿using Open.Text.CSV;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/Open.Text.Csv/
+    /// Source: https://github.com/Open-NET-Libraries/Open.Text.CSV/
+    /// </summary>
+    public class Open_Text_CSV : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public Open_Text_CSV(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+            using (var reader = new StreamReader(stream))
+            {
+                var csvReader = new CsvReader(reader);
+
+                IEnumerable<string> fields;
+                while ((fields = csvReader.ReadNextRow()) != null)
+                {
+                    var record = activate();
+                    var enu = fields.GetEnumerator();
+                    record.Read(i => { enu.MoveNext(); return enu.Current; });
+                    allRecords.Add(record);
+                }
+            }
+
+            return allRecords;
+        }
+    }
+}

--- a/NCsvPerf/CsvReadable/KBCsv.cs
+++ b/NCsvPerf/CsvReadable/KBCsv.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Sylvan;
+using KBCsv;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/KBCsv/
+    /// Source: https://github.com/kentcb/KBCsv
+    /// </summary>
+    public class KB_Csv : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public KB_Csv(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+            var stringPool = new StringPool(128);
+
+            using (var reader = new StreamReader(stream))
+            using (var csvReader = new CsvReader(reader))
+            {
+                while (csvReader.HasMoreRecords)
+                {
+                    var row = csvReader.ReadDataRecord();
+
+                    var record = activate();
+                    record.Read(i => row[i]);
+                    allRecords.Add(record);
+                }
+            }
+
+            return allRecords;
+        }
+    }
+}

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cesil" Version="0.9.0" />
     <PackageReference Include="FSharp.Core" Version="5.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
 

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -7,9 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="5.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+
+
+    <PackageReference Include="Angara.Table" Version="0.3.3" />
     <PackageReference Include="Ben.StringIntern" Version="0.1.8" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageReference Include="ChoETL" Version="1.2.1.18" />
+    <PackageReference Include="ChoETL" Version="1.2.1.22" />
     <PackageReference Include="Csv" Version="2.0.62" />
     <PackageReference Include="CSVFile" Version="3.0.2" />
     <PackageReference Include="CsvHelper" Version="27.1.1" />
@@ -17,24 +22,30 @@
     <PackageReference Include="CsvTools" Version="1.0.12" NoWarn="NU1701" />
     <PackageReference Include="Ctl.Data" Version="2.0.0.2" />
     <PackageReference Include="Cursively" Version="1.2.0" />
+    <PackageReference Include="Dsv" Version="1.3.1" />
+    <PackageReference Include="FileHelpers" Version="3.5.0" />
     <PackageReference Include="FlatFiles" Version="4.16.0" />
+    <PackageReference Include="KBCsv" Version="6.0.0" />
     <PackageReference Include="Knapcode.CommonLibrary.NET" Version="0.9.8.8-beta.3" NoWarn="NU1701" />
     <PackageReference Include="Knapcode.FastCsvParser" Version="1.1.0" />
     <PackageReference Include="FluentCSV" Version="3.0.0" />
     <PackageReference Include="LinqToCsv" Version="1.5.0" NoWarn="NU1701" />
     <PackageReference Include="LumenWorksCsvReader" Version="4.0.0" />
     <PackageReference Include="mgholam.fastCSV" Version="2.0.9" />
+    <PackageReference Include="Microsoft.Data.Analysis" Version="0.18.0" />
+    <PackageReference Include="Microsoft.ML" Version="1.6.0" />
     <PackageReference Include="NReco.Csv" Version="1.0.0" />
+    <PackageReference Include="Open.Text.CSV" Version="2.3.2" />
     <PackageReference Include="RecordParser" Version="1.2.0" />
     <PackageReference Include="ServiceStack.Text" Version="5.11.0" />
     <PackageReference Include="Sky.Data.Csv" Version="2.5.0" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="3.0.0" />
     <PackageReference Include="Sylvan.Common" Version="0.2.1" />
-    <PackageReference Include="Sylvan.Data.Csv" Version="1.0.3" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="1.1.4" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="TinyCsvParser" Version="2.6.1" />
 
-    <PackageReference Include="TxtCsvHelper" Version="1.2.9" />
+    <PackageReference Include="TxtCsvHelper" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Cesil" Version="0.9.0" />
     <PackageReference Include="FSharp.Core" Version="5.0.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
 
 
     <PackageReference Include="Angara.Table" Version="0.3.3" />
@@ -42,7 +42,7 @@
     <PackageReference Include="Sky.Data.Csv" Version="2.5.0" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="3.0.0" />
     <PackageReference Include="Sylvan.Common" Version="0.2.1" />
-    <PackageReference Include="Sylvan.Data.Csv" Version="1.1.4" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="1.1.5" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="TinyCsvParser" Version="2.6.1" />
 

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.18.0" />
     <PackageReference Include="Microsoft.ML" Version="1.6.0" />
     <PackageReference Include="NReco.Csv" Version="1.0.0" />
-    <PackageReference Include="Open.Text.CSV" Version="2.3.2" />
+    <PackageReference Include="Open.Text.CSV" Version="2.3.3" />
     <PackageReference Include="RecordParser" Version="1.2.0" />
     <PackageReference Include="ServiceStack.Text" Version="5.11.0" />
     <PackageReference Include="Sky.Data.Csv" Version="2.5.0" />


### PR DESCRIPTION
Looks like I missed the last round by a couple of days, bummer. This adds a bunch of new libraries for the next update, and should close out some of the open issues.

Angara.Table from #15 
FileHelpers from #13 
Microsoft.ML from #5 
Open.Text.CSV
DSV
KBCsv
Microsoft.Data.Analysis

Three of these are from Microsoft, as it appears that Angara.Table is an MS research thing, and is an F# library. Working with that one makes me wonder if using C# libraries in F# feels as clunky as F# libraries feel in C#.

The FileHelpers implementation might look a bit funny as it parses to a "temporary" object (it only binds to objects, no raw access) and then that temporary is copied to the final PackageAsset. I also tried having it bind directly to the PackageAsset, but surprisingly that ended up being slower anyway.

I also updated packages to the latest versions.