### PR TITLE
modify benchmarks to run more quickly

### DIFF
--- a/NCsvPerf.Test/CsvReadable/Benchmarks/PackageAssetsSuiteTest.cs
+++ b/NCsvPerf.Test/CsvReadable/Benchmarks/PackageAssetsSuiteTest.cs
@@ -60,9 +60,14 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             Assert.Single(groups);
         }
 
-        public static IEnumerable<object[]> TestData => PackageAssetsSuite
-            .LineCountSource
-            .Where(x => x <= 10_000)
-            .Select(x => new object[] { x });
+        public static IEnumerable<object[]> TestData
+        {
+            get {
+                yield return new object[] { 0 };
+                yield return new object[] { 1 };
+                yield return new object[] { 100 };
+                yield return new object[] { 10_000 };
+            }
+        }
     }
 }

--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Attributes;
 namespace Knapcode.NCsvPerf.CsvReadable.TestCases
 {
     [MemoryDiagnoser]
+    [SimpleJob(1, 2, 4, 1)]
     public class PackageAssetsSuite
     {
         private byte[] _bytes;
@@ -24,7 +25,11 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         [ParamsSource(nameof(LineCountSource))]
         public int LineCount { get; set; }
 
-        public static IReadOnlyList<int> LineCountSource { get; } = new[] { 0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000 };
+        public static IReadOnlyList<int> LineCountSource { get; } =
+            new[] { 
+                //0, 1, 10, 100, 1_000, 10_000, 100_000, 
+                1_000_000
+            };
 
         [GlobalSetup]
         public void GlobalSetup()


### PR DESCRIPTION
Modifies the configuration a bit to run the 1M benchmark in a reasonable time. The default configuration runs way more iterations than are really needed, which just makes the run take a long time but doesn't really effect the results.