### PR TITLE
update packages and target framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.100-preview.7.21379.14
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/NCsvPerf.Test/NCsvPerf.Test.csproj
+++ b/NCsvPerf.Test/NCsvPerf.Test.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Knapcode.NCsvPerf.Test</RootNamespace>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -2,16 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Knapcode.NCsvPerf</RootNamespace>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Angara.Table" Version="0.3.3" NoWarn="NU1701" />
     <PackageReference Include="Angara.Serialization" Version="0.3.0" NoWarn="NU1701" />
-    <PackageReference Include="Angara.Statistics" Version="0.1.0" NoWarn="NU1701" />
+    <PackageReference Include="Angara.Statistics" Version="0.1.4" NoWarn="NU1701" />
     <PackageReference Include="Ben.StringIntern" Version="0.1.8" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="Cesil" Version="0.9.0" />
     <PackageReference Include="ChoETL" Version="1.2.1.22" />
     <PackageReference Include="Csv" Version="2.0.62" />
@@ -35,13 +36,13 @@
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.18.0" />
     <PackageReference Include="Microsoft.ML" Version="1.6.0" />
     <PackageReference Include="NReco.Csv" Version="1.0.0" />
-    <PackageReference Include="Open.Text.CSV" Version="2.3.3" />
+    <PackageReference Include="Open.Text.CSV" Version="2.4.0" />
     <PackageReference Include="RecordParser" Version="1.2.0" />
     <PackageReference Include="ServiceStack.Text" Version="5.11.0" />
     <PackageReference Include="Sky.Data.Csv" Version="2.5.0" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="3.0.0" />
     <PackageReference Include="Sylvan.Common" Version="0.2.1" />
-    <PackageReference Include="Sylvan.Data.Csv" Version="1.1.5" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="1.1.6" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" NoWarn="NU1608" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="TinyCsvParser" Version="2.6.1" />


### PR DESCRIPTION
Update to the latest version of packages including the 1.1.6 Sylvan with the Zen2 performance fix. Thanks again Joel for helping test that. I also updated the framework to net6.0. I'm seeing that there was another noticeable performance improvement between preview 6 and preview 7 that gives everyone a bit of a speed-up. The `<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>` should only be needed until the next RC, when that change in default behavior will be reverted.