### PR TITLE
ICsvReader returns IEnumerable instead of List

### DIFF
--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 
 namespace Knapcode.NCsvPerf.CsvReadable.TestCases
@@ -43,14 +44,16 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             {
                 var result = reader.GetRecords<PackageAsset>(memoryStream);
 
-                if (result.Count != LineCount)
-                {
-                    throw new InvalidDataException($"ICsvReader '{reader.GetType().FullName}' failed to produce correct number of rows. Expected: {LineCount}, actual: {result.Count}.");
-                }
-
                 if (_saveResult)
                 {
-                    LatestResult = result;
+                    result = LatestResult = result.ToList();
+                }
+
+                var count = result.Count();
+
+                if (count != LineCount)
+                {
+                    throw new InvalidDataException($"ICsvReader '{reader.GetType().FullName}' failed to produce correct number of rows. Expected: {LineCount}, actual: {count}.");
                 }
             }
         }

--- a/NCsvPerf/CsvReadable/ICsvReader.cs
+++ b/NCsvPerf/CsvReadable/ICsvReader.cs
@@ -5,6 +5,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
 {
     public interface ICsvReader
     {
-        List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new();
+        IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new();
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Angara_Table.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Angara_Table.cs
@@ -38,14 +38,12 @@ namespace Knapcode.NCsvPerf.CsvReadable
             {
                 var cols = new FSharpOption<FSharpFunc<Tuple<int, string>, FSharpOption<Type>>>(new Types());
                 var table = Table.Load(reader, new ReadSettings(Delimiter.Comma, false, false, FSharpOption<int>.None, cols));
-                var allRecords = new List<T>(table.RowsCount);
                 for (int r = 0; r < table.RowsCount; r++)
                 {
                     var item = activate();
                     item.Read(i => table[i].Rows.Item(r).AsString);
-                    allRecords.Add(item);
+                    yield return item;
                 }
-                return allRecords;
             }
         }
     }

--- a/NCsvPerf/CsvReadable/Implementations/Angara_Table.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Angara_Table.cs
@@ -30,7 +30,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             }
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
 

--- a/NCsvPerf/CsvReadable/Implementations/CSVFile.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CSVFile.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/CSVFile.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CSVFile.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             var config = new global::CSVFile.CSVSettings
             {
@@ -32,11 +31,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => row[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Cesil.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Cesil.cs
@@ -19,29 +19,27 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             // specialize for T == PackageAsset
-            return GetAssets(stream) as List<T>;
+            return GetAssets(stream) as IEnumerable<T>;
         }
 
-        public List<PackageAsset> GetAssets(MemoryStream stream) {
-            var allRecords = new List<PackageAsset>();
+        public IEnumerable<PackageAsset> GetAssets(MemoryStream stream) {
             using (var reader = new StreamReader(stream))
             {
                 var config = Configuration.For<PackageAsset>();
                 var csv = config.CreateReader(reader);
                 foreach (var row in csv.EnumerateAll())
                 {
-                    allRecords.Add(row);
                     // for some reason this final field is null for certain records
                     // which was causing tests to fail
                     if (row.PlatformVersion == null)
                         row.PlatformVersion = "";
+
+                    yield return row;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/ChoEtl.cs
+++ b/NCsvPerf/CsvReadable/Implementations/ChoEtl.cs
@@ -17,13 +17,11 @@ namespace Knapcode.NCsvPerf.CsvReadable
 
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
-            return GetAssets(stream) as List<T>;
+            return GetAssets(stream) as IEnumerable<T>;
         }
 
-        List<PackageAsset> GetAssets(MemoryStream stream)
+        IEnumerable<PackageAsset> GetAssets(MemoryStream stream)
         {
-            var allRecords = new List<PackageAsset>();
-
             var config = new global::ChoETL.ChoCSVRecordConfiguration
             {
                 FileHeaderConfiguration = new global::ChoETL.ChoCSVFileHeaderConfiguration
@@ -37,10 +35,8 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var asset = new PackageAsset();
                     asset.Read(i => record.GetString(i));
-                    allRecords.Add(asset);
+                    yield return asset;
                 }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/ChoEtl.cs
+++ b/NCsvPerf/CsvReadable/Implementations/ChoEtl.cs
@@ -15,7 +15,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
         {
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             return GetAssets(stream) as List<T>;
         }

--- a/NCsvPerf/CsvReadable/Implementations/CommonLibrary_Net.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CommonLibrary_Net.cs
@@ -22,7 +22,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             string text;
             using (var reader = new StreamReader(stream))
@@ -37,11 +36,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => row[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/CommonLibrary_Net.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CommonLibrary_Net.cs
@@ -19,7 +19,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Csv.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -33,11 +32,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => row[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Csv.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/CsvHelper.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CsvHelper.cs
@@ -17,7 +17,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/CsvHelper.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CsvHelper.cs
@@ -20,7 +20,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -33,11 +32,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => csvParser[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/CsvTextFieldParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CsvTextFieldParser.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/CsvTextFieldParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CsvTextFieldParser.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -29,11 +28,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var fields = parser.ReadFields();
                     var record = activate();
                     record.Read(i => fields[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/CsvTools.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CsvTools.cs
@@ -18,7 +18,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/CsvTools.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CsvTools.cs
@@ -21,7 +21,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             if (stream.Length > 0)
             {
@@ -30,17 +29,15 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 // Read header as a row.
                 var r = activate();
                 r.Read(i => table.ColumnNames.ElementAt(i));
-                allRecords.Add(r);
+                yield return r;
 
                 foreach (var row in table.Rows)
                 {
                     var record = activate();
                     record.Read(i => row.Values[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Ctl_Data.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Ctl_Data.cs
@@ -17,7 +17,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/Ctl_Data.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Ctl_Data.cs
@@ -20,7 +20,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var streamReader = new StreamReader(stream))
             {
@@ -32,11 +31,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     // Empty fields are returned as null by this library. Convert that to empty string to be more
                     // consistent with other libraries.
                     record.Read(i => csvReader.CurrentRow[i].Value ?? string.Empty);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Cursively.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Cursively.cs
@@ -27,7 +27,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             using var vis = new Vis<T>(_activationMethod);
             if (stream.TryGetBuffer(out var buf))

--- a/NCsvPerf/CsvReadable/Implementations/DSV.cs
+++ b/NCsvPerf/CsvReadable/Implementations/DSV.cs
@@ -18,7 +18,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/DSV.cs
+++ b/NCsvPerf/CsvReadable/Implementations/DSV.cs
@@ -21,7 +21,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -30,11 +29,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => row[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
 
         static IEnumerable<string> EnumerateLines(TextReader r)

--- a/NCsvPerf/CsvReadable/Implementations/FastCsvParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FastCsvParser.cs
@@ -24,7 +24,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var parser = new global::FastCsvParser.CsvReader(stream, Encoding.UTF8))
             {
@@ -32,11 +31,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => parser.Current[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/FastCsvParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FastCsvParser.cs
@@ -21,7 +21,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
@@ -17,7 +17,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
@@ -20,7 +20,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -36,12 +35,10 @@ namespace Knapcode.NCsvPerf.CsvReadable
                         // bind directly to the PackageAsset.
                         var record = activate();
                         record.Read(i => item.GetString(i));
-                        allRecords.Add(record);
+                        yield return record;
                     }
                 }
             }
-
-            return allRecords;
         }
         [global::FileHelpers.DelimitedRecord(",")]
         public class PackageAssetData

--- a/NCsvPerf/CsvReadable/Implementations/FlatFiles.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FlatFiles.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -30,11 +29,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var values = csvReader.GetValues();
                     var record = activate();
                     record.Read(i => values[i]?.ToString() ?? string.Empty);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/FlatFiles.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FlatFiles.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/FluentCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FluentCsv.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/FluentCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FluentCsv.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -30,11 +29,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var row = splitter.SplitColumns(line, ",");
                     var record = activate();
                     record.Read(i => row[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/HomeGrown.cs
+++ b/NCsvPerf/CsvReadable/Implementations/HomeGrown.cs
@@ -18,7 +18,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/HomeGrown.cs
+++ b/NCsvPerf/CsvReadable/Implementations/HomeGrown.cs
@@ -21,7 +21,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
             var fields = new List<string>();
             var builder = new StringBuilder();
 
@@ -31,11 +30,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => fields[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/KBCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/KBCsv.cs
@@ -18,7 +18,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/KBCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/KBCsv.cs
@@ -21,7 +21,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
             var stringPool = new StringPool(128);
 
             using (var reader = new StreamReader(stream))
@@ -33,11 +32,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
 
                     var record = activate();
                     record.Read(i => row[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/LinqToCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/LinqToCsv.cs
@@ -17,7 +17,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/LinqToCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/LinqToCsv.cs
@@ -20,7 +20,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -33,11 +32,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => row[i].Value ?? string.Empty);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
 
         private class DataRow : List<DataRowItem>, IDataRow

--- a/NCsvPerf/CsvReadable/Implementations/LumenWorksCsvReader.cs
+++ b/NCsvPerf/CsvReadable/Implementations/LumenWorksCsvReader.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             using (var csvReader = new LumenWorks.Framework.IO.Csv.CsvReader(reader, hasHeaders: false))
@@ -28,11 +27,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => csvReader[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/LumenWorksCsvReader.cs
+++ b/NCsvPerf/CsvReadable/Implementations/LumenWorksCsvReader.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_Data_Analsysis.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_Data_Analsysis.cs
@@ -21,7 +21,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_Data_Analsysis.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_Data_Analsysis.cs
@@ -24,7 +24,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             // This only works for data with exactly 25 columns.
             // You must either provide the column types, or the types will be
@@ -38,17 +37,15 @@ namespace Knapcode.NCsvPerf.CsvReadable
             catch(FormatException e)
             {
                 if (e.Message == "Empty file")
-                    return allRecords;
+                    yield break;
                 throw;
             }
             foreach (var row in frame.Rows)
             {
                 var record = activate();
                 record.Read(i => row[i].ToString());
-                allRecords.Add(record);
+                yield return record;
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
@@ -20,7 +20,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             // this library only allows loading from a file.
             // so write to a local file, use the length of the memory stream

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
@@ -35,7 +35,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
             }
 
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
             var mlc = new MLContext();
 
             using (var reader = new StreamReader(stream))
@@ -55,11 +54,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => { ReadOnlyMemory<char> s = null; getters[i](ref s); return s.ToString(); });
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_VisualBasic_FileIO_TextFieldParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_VisualBasic_FileIO_TextFieldParser.cs
@@ -17,7 +17,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_VisualBasic_FileIO_TextFieldParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_VisualBasic_FileIO_TextFieldParser.cs
@@ -20,7 +20,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var parser = new TextFieldParser(stream))
             {
@@ -31,11 +30,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var fields = parser.ReadFields();
                     var record = activate();
                     record.Read(i => fields[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/NReco_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/NReco_Csv.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/NReco_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/NReco_Csv.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -28,11 +27,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => csvReader[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Open_Text_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Open_Text_Csv.cs
@@ -17,7 +17,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/Open_Text_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Open_Text_Csv.cs
@@ -20,7 +20,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
             using (var reader = new StreamReader(stream))
             {
                 var csvReader = new CsvReader(reader);
@@ -31,11 +30,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var record = activate();
                     var enu = fields.GetEnumerator();
                     record.Read(i => { enu.MoveNext(); return enu.Current; });
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/RecordParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/RecordParser.cs
@@ -22,7 +22,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var reader = BuildReader(activate);

--- a/NCsvPerf/CsvReadable/Implementations/RecordParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/RecordParser.cs
@@ -69,10 +69,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
             return reader;
         }
 
-        private static List<T> ProcessStream<T>(MemoryStream stream, FuncSpanT<T> parser)
+        private static IEnumerable<T> ProcessStream<T>(MemoryStream stream, FuncSpanT<T> parser)
         {
             var reader = PipeReader.Create(stream);
-            var records = new List<T>();
 
             while (true)
             {
@@ -82,7 +81,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var item = ProcessSequence(sequence, parser);
 
-                    records.Add(item);
+                    yield return item;
                 }
 
                 reader.AdvanceTo(buffer.Start, buffer.End);
@@ -91,8 +90,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     break;
                 }
             }
-
-            return records;
         }
 
         private static bool TryReadLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> line)

--- a/NCsvPerf/CsvReadable/Implementations/ServiceStack_Text.cs
+++ b/NCsvPerf/CsvReadable/Implementations/ServiceStack_Text.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/ServiceStack_Text.cs
+++ b/NCsvPerf/CsvReadable/Implementations/ServiceStack_Text.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -31,11 +30,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     // Empty fields are returned as null by this library. Convert that to empty string to be more
                     // consistent with other libraries.
                     record.Read(i => fields[i] ?? string.Empty);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Sky_Data_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Sky_Data_Csv.cs
@@ -19,17 +19,14 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             var csvReader = Sky.Data.Csv.CsvReader.Create(stream);
             foreach (var row in csvReader)
             {
                 var record = activate();
                 record.Read(i => row[i]);
-                allRecords.Add(record);
+                yield return record;
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Sky_Data_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Sky_Data_Csv.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/SoftCircuits_CsvParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/SoftCircuits_CsvParser.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/SoftCircuits_CsvParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/SoftCircuits_CsvParser.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new SoftCircuits.CsvParser.CsvReader(stream))
             {
@@ -28,11 +27,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => columns[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/Sylvan_Data_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Sylvan_Data_Csv.cs
@@ -18,7 +18,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/Sylvan_Data_Csv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Sylvan_Data_Csv.cs
@@ -21,7 +21,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
             var stringPool = new StringPool(128);
 
             using (var reader = new StreamReader(stream))
@@ -38,11 +37,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 {
                     var record = activate();
                     record.Read(i => csvReader.GetString(i));
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/TinyCsvParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/TinyCsvParser.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -32,11 +31,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var record = activate();
                     var fields = tokenizer.Tokenize(line);
                     record.Read(i => fields[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/TinyCsvParser.cs
+++ b/NCsvPerf/CsvReadable/Implementations/TinyCsvParser.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/TxtCsvHelper.cs
+++ b/NCsvPerf/CsvReadable/Implementations/TxtCsvHelper.cs
@@ -23,7 +23,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
             using (var reader = new StreamReader(stream))
             using (var txt = new global::TxtCsvHelper.Parser())
             {
@@ -34,10 +33,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var strings = txt.MixedSplit(reader.ReadLine()).ToList();
                     var record = activate();
                     record.Read(i => strings[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-            return allRecords;
         }
     }
 }

--- a/NCsvPerf/CsvReadable/Implementations/TxtCsvHelper.cs
+++ b/NCsvPerf/CsvReadable/Implementations/TxtCsvHelper.cs
@@ -20,7 +20,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/mgholam_fastCSV.cs
+++ b/NCsvPerf/CsvReadable/Implementations/mgholam_fastCSV.cs
@@ -9,7 +9,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
     /// </summary>
     public class mgholam_fastCSV : ICsvReader
     {
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             using (var reader = new StreamReader(stream))
             {

--- a/NCsvPerf/CsvReadable/Implementations/string_Split.cs
+++ b/NCsvPerf/CsvReadable/Implementations/string_Split.cs
@@ -16,7 +16,7 @@ namespace Knapcode.NCsvPerf.CsvReadable
             _activationMethod = activationMethod;
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();

--- a/NCsvPerf/CsvReadable/Implementations/string_Split.cs
+++ b/NCsvPerf/CsvReadable/Implementations/string_Split.cs
@@ -19,7 +19,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         public IEnumerable<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
-            var allRecords = new List<T>();
 
             using (var reader = new StreamReader(stream))
             {
@@ -29,11 +28,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     var pieces = line.Split(',');
                     var record = activate();
                     record.Read(i => pieces[i]);
-                    allRecords.Add(record);
+                    yield return record;
                 }
             }
-
-            return allRecords;
         }
     }
 }


### PR DESCRIPTION
Usually we should _program to interfaces, not implementations_, to abstract implementation details and focus on behaviour.
I think it is more fair does not obligate implementations to return a specific type (eg. List<T>) @joelverhagen 

If some implementation can work better with IEnumerable instead of List, I dont see any reason to force it get worse. 

Obligate implementations to use list hurt performances unnecessarily because as the size of the list gets larger, it has the cost of creating a new buffer internally and copy over all of the existing elements. 

So this PR makes 2 adjusts:

1. adjusts to ICsvReader returns IEnumerable instead of List<T> 
2. adjusts some implementations to use `yield return` instead of mandatorily return a List<T>

I can revert point 2 if wanted.  


