### PR TITLE
Add Sep - the fastest yet

### DIFF
--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -218,6 +218,12 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         }
 
         [Benchmark]
+        public void Sep()
+        {
+            Execute(new Sep(ActivationMethod.ILEmit));
+        }
+
+        [Benchmark]
         public void ServiceStack_Text()
         {
             Execute(new ServiceStack_Text(ActivationMethod.ILEmit));

--- a/NCsvPerf/CsvReadable/Implementations/Sep.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Sep.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using nietras.SeparatedValues;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    /// <summary>
+    /// Package: https://www.nuget.org/packages/Sep/
+    /// Source: https://github.com/nietras/Sep
+    /// </summary>
+    public class Sep : ICsvReader
+    {
+        private readonly ActivationMethod _activationMethod;
+
+        public Sep(ActivationMethod activationMethod)
+        {
+            _activationMethod = activationMethod;
+        }
+
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            var activate = ActivatorFactory.Create<T>(_activationMethod);
+            var allRecords = new List<T>();
+
+            using var reader = nietras.SeparatedValues.Sep.Reader(o => o with
+            {
+                HasHeader = false,
+                CreateToString = SepToString.PoolPerCol(maximumStringLength: 128),
+            })
+            .From(stream);
+
+            // Due to how NCsvPerf code is factored and that Sep uses ref
+            // structs, the code below is different from normal Sep usage.
+            Func<int, string> toString = reader.ToString;
+            foreach (var row in reader)
+            {
+                var record = activate();
+                record.Read(toString);
+                allRecords.Add(record);
+            }
+
+            return allRecords;
+        }
+    }
+}

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="NReco.Csv" Version="1.0.1" />
     <PackageReference Include="Open.Text.CSV" Version="3.3.0" />
     <PackageReference Include="RecordParser" Version="1.3.0" />
+    <PackageReference Include="Sep" Version="0.1.0-rc.1" />
     <PackageReference Include="ServiceStack.Text" Version="6.7.0" />
     <PackageReference Include="Sky.Data.Csv" Version="2.5.0" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="4.0.0" />

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="NReco.Csv" Version="1.0.1" />
     <PackageReference Include="Open.Text.CSV" Version="3.3.0" />
     <PackageReference Include="RecordParser" Version="1.3.0" />
-    <PackageReference Include="Sep" Version="0.1.0-rc.1" />
+    <PackageReference Include="Sep" Version="0.1.0" />
     <PackageReference Include="ServiceStack.Text" Version="6.7.0" />
     <PackageReference Include="Sky.Data.Csv" Version="2.5.0" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="4.0.0" />


### PR DESCRIPTION
@joelverhagen cc @JoshClose @MarkPflug this adds [Sep](https://github.com/nietras/Sep) a new library. As seen below this should be about 1.3x faster than Sylvan, sorry! 😅 Awaiting official results before introducing this to the world on my blog [nietras.com](https://nietras.com).

``` ini
BenchmarkDotNet=v0.13.5, OS=Windows 10 (10.0.19044.2965/21H2/November2021Update)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.203
  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
  Job-PCYXTT : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2

InvocationCount=1  IterationCount=6  LaunchCount=1  
UnrollFactor=1  WarmupCount=2  
```
|          Method | LineCount |       Mean |    Error |   StdDev |       Gen0 |       Gen1 |      Gen2 | Allocated |
|---------------- |---------- |-----------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
|       CsvHelper |   1000000 | 2,139.1 ms | 53.65 ms | 19.13 ms | 18000.0000 | 17000.0000 | 3000.0000 | 260.59 MB |
|             Sep |   1000000 |   733.0 ms | 21.03 ms |  7.50 ms | 18000.0000 | 17000.0000 | 3000.0000 | 260.42 MB |
| Sylvan_Data_Csv |   1000000 |   936.0 ms | 25.39 ms |  9.05 ms | 18000.0000 | 17000.0000 | 3000.0000 | 260.77 MB |
