### PR TITLE
Make the benchmark unit test pass in the presence of quoted fields.

### DIFF
--- a/NCsvPerf.Test/CsvReadable/Benchmarks/PackageAssetsSuiteTest.cs
+++ b/NCsvPerf.Test/CsvReadable/Benchmarks/PackageAssetsSuiteTest.cs
@@ -27,6 +27,9 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
                 .GetType()
                 .GetMethods()
                 .Where(x => x.GetCustomAttributes(typeof(BenchmarkAttribute), inherit: false).Any())
+                // the naive string.Split implementation is not expected
+                // to produce correct results.
+                .Where(m => m.Name != "string_Split")
                 .ToList();
             var results = new Dictionary<string, List<PackageAsset>>();
 

--- a/NCsvPerf.Test/CsvReadable/Benchmarks/PackageAssetsSuiteTest.cs
+++ b/NCsvPerf.Test/CsvReadable/Benchmarks/PackageAssetsSuiteTest.cs
@@ -1,8 +1,9 @@
+using BenchmarkDotNet.Attributes;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using BenchmarkDotNet.Attributes;
-using Newtonsoft.Json;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,12 +18,49 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             _output = output;
         }
 
+        public static IEnumerable<object[]> LineCounts
+        {
+            get
+            {
+                yield return new object[] { 0 };
+                yield return new object[] { 1 };
+                yield return new object[] { 100 };
+                yield return new object[] { 10_000 };
+            }
+        }
+
         [Theory]
-        [MemberData(nameof(TestData))]
+        [MemberData(nameof(LineCounts))]
         public void AllBenchmarksHaveSameOutput(int lineCount)
+        {
+            var data = TestData.PackageAssets.GetBytes(lineCount);
+            AllBenchmarksAgree(data, lineCount.ToString());
+        }
+
+        public static IEnumerable<object[]> Files
+        {
+            get
+            {
+                yield return new[] { "Quoted.csv" };
+                yield return new[] { "QuotedComma.csv" };
+                yield return new[] { "QuotedNewLine.csv" };
+                yield return new[] { "QuotedQuote.csv" };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Files))]
+        public void AllBenchmarksHaveSameOutput2(string file)
+        {
+            var data = File.ReadAllBytes(file);
+            AllBenchmarksAgree(data, Path.GetFileNameWithoutExtension(file));
+        }
+
+        void AllBenchmarksAgree(byte[] data, string id)
         {
             // Arrange
             var suite = new PackageAssetsSuite(saveResult: true);
+            suite.fileId = id;
             var benchmarks = suite
                 .GetType()
                 .GetMethods()
@@ -36,26 +74,44 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             // Act
             foreach (var benchmark in benchmarks)
             {
-                suite.LineCount = lineCount;
-                suite.GlobalSetup();
-                benchmark.Invoke(suite, null);
-                results.Add(benchmark.Name, suite.LatestResult);
+                suite.SetData(data);
+                try
+                {
+                    benchmark.Invoke(suite, null);
+                    results.Add(benchmark.Name, suite.LatestResult);
+                }
+                catch
+                {
+                    results.Add(benchmark.Name, null);
+                }
+            }
+
+            static string GetValue(List<PackageAsset> assets)
+            {
+                return assets == null
+                    ? "Failed"
+                    : assets.Count == 0
+                    ? "No records"
+                    : assets[0].Id;
             }
 
             // Assert
             var groups = results
-                .GroupBy(p => JsonConvert.SerializeObject(p.Value, Formatting.Indented), p => p.Key)
+                .GroupBy(p => JsonConvert.SerializeObject(p.Value, Formatting.Indented), p => new { Key = p.Key,  Id = GetValue(p.Value) })
                 .OrderByDescending(x => x.Count())
                 .ToList();
+
             var number = 0;
             foreach (var group in groups)
             {
                 number++;
-                _output.WriteLine($"Group #{number} (result JSON length = {group.Key.Length}):");
+                var value = group.First().Id;
+                _output.WriteLine($"Group #{number} (result JSON length = {group.Key.Length}, Output = {Escape(value)}):");
                 File.WriteAllText($"group-{number}.json", group.Key);
                 foreach (var benchmark in group)
                 {
-                    _output.WriteLine($"  - {benchmark}");
+
+                    _output.WriteLine($"  - {benchmark.Key}");
                 }
                 _output.WriteLine(string.Empty);
             }
@@ -63,14 +119,22 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
             Assert.Single(groups);
         }
 
-        public static IEnumerable<object[]> TestData
+        static string Escape(string s)
         {
-            get {
-                yield return new object[] { 0 };
-                yield return new object[] { 1 };
-                yield return new object[] { 100 };
-                yield return new object[] { 10_000 };
+            var sb = new StringBuilder();
+            for (int i = 0; i < s.Length; i++)
+            {
+                var c = s[i];
+                if (char.IsControl(c))
+                {
+                    sb.Append($"\\x{(int)c:x2}");
+                }
+                else
+                {
+                    sb.Append(c);
+                }
             }
+            return sb.ToString();
         }
     }
 }

--- a/NCsvPerf.Test/NCsvPerf.Test.csproj
+++ b/NCsvPerf.Test/NCsvPerf.Test.csproj
@@ -1,23 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <RootNamespace>Knapcode.NCsvPerf.Test</RootNamespace>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<RootNamespace>Knapcode.NCsvPerf.Test</RootNamespace>
+		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\NCsvPerf\NCsvPerf.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\NCsvPerf\NCsvPerf.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="*.csv">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/NCsvPerf.Test/Quoted.csv
+++ b/NCsvPerf.Test/Quoted.csv
@@ -1,0 +1,1 @@
+75fcf875-017d-4579-bfd9-791d3e6767f0,2020-11-28T01:50:41.2449947+00:00,"Akinzekeel.BlazorGrid",0.9.1-preview,2020-11-27T22:42:54.3100000+00:00,AvailableAssets,RuntimeAssemblies,,,net5.0,,,,,,lib/net5.0/BlazorGrid.dll,BlazorGrid.dll,.dll,lib,net5.0,.NETCoreApp,5.0.0.0,,,0.0.0.0

--- a/NCsvPerf.Test/QuotedComma.csv
+++ b/NCsvPerf.Test/QuotedComma.csv
@@ -1,0 +1,1 @@
+75fcf875-017d-4579-bfd9-791d3e6767f0,2020-11-28T01:50:41.2449947+00:00,"Akinzekeel,BlazorGrid",0.9.1-preview,2020-11-27T22:42:54.3100000+00:00,AvailableAssets,RuntimeAssemblies,,,net5.0,,,,,,lib/net5.0/BlazorGrid.dll,BlazorGrid.dll,.dll,lib,net5.0,.NETCoreApp,5.0.0.0,,,0.0.0.0

--- a/NCsvPerf.Test/QuotedNewLine.csv
+++ b/NCsvPerf.Test/QuotedNewLine.csv
@@ -1,0 +1,2 @@
+75fcf875-017d-4579-bfd9-791d3e6767f0,2020-11-28T01:50:41.2449947+00:00,"Akinzekeel
+BlazorGrid",0.9.1-preview,2020-11-27T22:42:54.3100000+00:00,AvailableAssets,RuntimeAssemblies,,,net5.0,,,,,,lib/net5.0/BlazorGrid.dll,BlazorGrid.dll,.dll,lib,net5.0,.NETCoreApp,5.0.0.0,,,0.0.0.0

--- a/NCsvPerf.Test/QuotedQuote.csv
+++ b/NCsvPerf.Test/QuotedQuote.csv
@@ -1,0 +1,1 @@
+75fcf875-017d-4579-bfd9-791d3e6767f0,2020-11-28T01:50:41.2449947+00:00,"Akinzekeel""BlazorGrid",0.9.1-preview,2020-11-27T22:42:54.3100000+00:00,AvailableAssets,RuntimeAssemblies,,,net5.0,,,,,,lib/net5.0/BlazorGrid.dll,BlazorGrid.dll,.dll,lib,net5.0,.NETCoreApp,5.0.0.0,,,0.0.0.0

--- a/NCsvPerf/CsvReadable/Implementations/ChoEtl.cs
+++ b/NCsvPerf/CsvReadable/Implementations/ChoEtl.cs
@@ -28,18 +28,28 @@ namespace Knapcode.NCsvPerf.CsvReadable
             {
                 FileHeaderConfiguration = new global::ChoETL.ChoCSVFileHeaderConfiguration
                 {
-                    HasHeaderRecord = false,
+                    HasHeaderRecord = false,                     
                 },
+                QuoteChar = '"',
+                QuoteEscapeChar = '\"',
+                EscapeQuoteAndDelimiter = true,
+                MayContainEOLInData = true,
+                
             };
 
             using (var reader = new StreamReader(stream))
-                foreach (var record in new global::ChoETL.ChoCSVReader<PackageAssetData>(reader, config))
+            {
+                var csvReader =
+                    new global::ChoETL.ChoCSVReader<PackageAssetData>(reader, config)
+                    .MayHaveQuotedFields(true, '\"');
+
+                foreach (var record in csvReader)
                 {
                     var asset = new PackageAsset();
                     asset.Read(i => record.GetString(i));
                     allRecords.Add(asset);
                 }
-
+            }
             return allRecords;
         }
     }

--- a/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
+++ b/NCsvPerf/CsvReadable/Implementations/FileHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using FileHelpers;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -46,33 +47,58 @@ namespace Knapcode.NCsvPerf.CsvReadable
         [global::FileHelpers.DelimitedRecord(",")]
         public class PackageAssetData
         {
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string ScanId { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string ScanTimestamp { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string Id { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string Version { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string Created { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string ResultType { get; set; }
 
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PatternSet { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertyAnyValue { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertyCodeLanguage { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertyTargetFrameworkMoniker { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertyLocale { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertyManagedAssembly { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertyMSBuild { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertyRuntimeIdentifier { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PropertySatelliteAssembly { get; set; }
 
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string Path { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string FileName { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string FileExtension { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]            
             public string TopLevelFolder { get; set; }
 
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string RoundTripTargetFrameworkMoniker { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string FrameworkName { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string FrameworkVersion { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string FrameworkProfile { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PlatformName { get; set; }
+            [FieldQuoted('"', QuoteMode.OptionalForBoth)]
             public string PlatformVersion { get; set; }
 
             public string GetString(int i)

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
@@ -15,18 +15,21 @@ namespace Knapcode.NCsvPerf.CsvReadable
     {
         private readonly ActivationMethod _activationMethod;
 
-        public Microsoft_ML(ActivationMethod activationMethod)
+        public Microsoft_ML(ActivationMethod activationMethod, string id)
         {
             _activationMethod = activationMethod;
+            this.file = "data" + id + ".csv";
         }
 
-        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        string file;
+
+        public List<T> GetRecords<T>(MemoryStream stream)
+            where T : ICsvReadable, new()
         {
             // this library only allows loading from a file.
             // so write to a local file, use the length of the memory stream
             // to write to a different file based on the input data
             // this will be executed during the first "warmup" run
-            var file = "data" + stream.Length + ".csv";
 
             if (!File.Exists(file))
             {
@@ -34,34 +37,38 @@ namespace Knapcode.NCsvPerf.CsvReadable
                 stream.CopyTo(data);
             }
 
+            return GetRecordsFromFile<T>(file);
+        }
+
+        public List<T> GetRecordsFromFile<T>(string file)
+            where T : ICsvReadable, new()
+        {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();
             var mlc = new MLContext();
 
-            using (var reader = new StreamReader(stream))
+            var schema = new TextLoader.Column[25];
+            for (int i = 0; i < schema.Length; i++)
             {
-                var schema = new TextLoader.Column[25];
-                for (int i = 0; i < schema.Length; i++)
-                {
-                    schema[i] = new TextLoader.Column("" + i, DataKind.String, i);
-                }
+                schema[i] = new TextLoader.Column("" + i, DataKind.String, i);
+            }
 
-                var opts = new TextLoader.Options() { 
-                    HasHeader = false, 
-                    Separators = new[] { ',' }, 
-                    Columns = schema,
-                    AllowQuoting = true,
-                };
-                var l = mlc.Data.LoadFromTextFile(file, opts);
-                var rc = l.GetRowCursor(l.Schema);
-                var cols = l.Schema.ToArray();
-                var getters = cols.Select(c => rc.GetGetter<ReadOnlyMemory<char>>(c)).ToArray();
-                while (rc.MoveNext())
-                {
-                    var record = activate();
-                    record.Read(i => { ReadOnlyMemory<char> s = null; getters[i](ref s); return s.ToString(); });
-                    allRecords.Add(record);
-                }
+            var opts = new TextLoader.Options()
+            {
+                HasHeader = false,
+                Separators = new[] { ',' },
+                Columns = schema,
+                AllowQuoting = true,
+            };
+            var l = mlc.Data.LoadFromTextFile(file, opts);
+            var rc = l.GetRowCursor(l.Schema);
+            var cols = l.Schema.ToArray();
+            var getters = cols.Select(c => rc.GetGetter<ReadOnlyMemory<char>>(c)).ToArray();
+            while (rc.MoveNext())
+            {
+                var record = activate();
+                record.Read(i => { ReadOnlyMemory<char> s = null; getters[i](ref s); return s.ToString(); });
+                allRecords.Add(record);
             }
 
             return allRecords;

--- a/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Microsoft_ML.cs
@@ -46,7 +46,12 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     schema[i] = new TextLoader.Column("" + i, DataKind.String, i);
                 }
 
-                var opts = new TextLoader.Options() { HasHeader = false, Separators = new[] { ',' }, Columns = schema };
+                var opts = new TextLoader.Options() { 
+                    HasHeader = false, 
+                    Separators = new[] { ',' }, 
+                    Columns = schema,
+                    AllowQuoting = true,
+                };
                 var l = mlc.Data.LoadFromTextFile(file, opts);
                 var rc = l.GetRowCursor(l.Schema);
                 var cols = l.Schema.ToArray();


### PR DESCRIPTION
The NCsvPerf benchmark PackageAssets.csv file doesn't contain quotes, but all existing parsers can be configured to produce consistent results in the presence of a quoted field. This PR adds the required configurations for a few odd libraries that don't do this be default. Note, this PR doesn't change the CSV file, so the benchmark still doesn't test correctness. To test this, I modified the PackageAssets.csv and changed >Akinzekeel.BlazorGrid< to >"Akinzekeel,BlazorGrid"< on the first row; adding quotes and a comma in the middle. I exclude string.Split from the unit test, since the naive implementation is expected to produce incorrect results.

This PR is a bit reactionary to @nietras submission of Sep #51, as Sep would be the only library that produces inconsistent results, since it doesn't trim or escape quoted values and I don't see any configuration to enable it. Personally, I see this as fundamental functionality that a CSV library should provide, as without it a user would have to implement their own mechanism to process values. It feels a bit misleading that parser claiming to be the fastest would be producing results that disagrees with every other CSV library. I think most users would be surprised by this behavior, even though it is clearly stated in the docs.