### PR TITLE
Add a compiler flag to disable string pooling

### DIFF
--- a/NCsvPerf/CsvReadable/Implementations/CsvHelper.cs
+++ b/NCsvPerf/CsvReadable/Implementations/CsvHelper.cs
@@ -26,7 +26,9 @@ namespace Knapcode.NCsvPerf.CsvReadable
             {
                 var config = new global::CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture)
                 {
+#if ENABLE_STRING_POOLING
                     CacheFields = true,
+#endif
                 };
                 var csvParser = new global::CsvHelper.CsvParser(reader, config);
                 while (csvParser.Read())

--- a/NCsvPerf/CsvReadable/Implementations/Cursively.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Cursively.cs
@@ -47,8 +47,10 @@ namespace Knapcode.NCsvPerf.CsvReadable
         {
             private readonly Activate<T> _activate;
 
-            private readonly MyStringPool _stringPool;
 
+#if ENABLE_STRING_POOLING
+            private readonly MyStringPool _stringPool;
+#endif
             private readonly byte[] _bytes = new byte[1024];
 
             private readonly List<string> _fields = new List<string>();
@@ -58,7 +60,10 @@ namespace Knapcode.NCsvPerf.CsvReadable
             public Vis(ActivationMethod activationMethod)
             {
                 _activate = ActivatorFactory.Create<T>(activationMethod);
+
+#if ENABLE_STRING_POOLING
                 _stringPool = new MyStringPool();
+#endif
             }
 
             public List<T> Records { get; } = new List<T>();
@@ -72,7 +77,11 @@ namespace Knapcode.NCsvPerf.CsvReadable
                     _bytesConsumed = 0;
                 }
 
+#if ENABLE_STRING_POOLING
                 _fields.Add(chunk.IsEmpty ? string.Empty : _stringPool.GetString(chunk));
+#else
+                _fields.Add(chunk.IsEmpty ? string.Empty : Encoding.UTF8.GetString(chunk));
+#endif
             }
 
             public override void VisitEndOfRecord()
@@ -92,7 +101,10 @@ namespace Knapcode.NCsvPerf.CsvReadable
 
             public void Dispose()
             {
+
+#if ENABLE_STRING_POOLING
                 _stringPool.Dispose();
+#endif
             }
         }
 

--- a/NCsvPerf/CsvReadable/Implementations/KBCsv.cs
+++ b/NCsvPerf/CsvReadable/Implementations/KBCsv.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using Sylvan;
 using KBCsv;
 
 namespace Knapcode.NCsvPerf.CsvReadable
@@ -22,7 +21,6 @@ namespace Knapcode.NCsvPerf.CsvReadable
         {
             var activate = ActivatorFactory.Create<T>(_activationMethod);
             var allRecords = new List<T>();
-            var stringPool = new StringPool(128);
 
             using (var reader = new StreamReader(stream))
             using (var csvReader = new CsvReader(reader))

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Knapcode.NCsvPerf</RootNamespace>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+	<DefineConstants>ENABLE_STRING_POOLING</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a global compiler flag to easily toggle "string pooling" on and off for the small number of libraries that support it. For "realistic" data sets string pooling would most likely slow things down. It is only beneficial here because of how the data set is created by repeating a relatively small number of rows. This leaves pooling enabled, so future runs will be consistent with past results.