### PR TITLE
Removes System.IO.Pipelines dependency

### DIFF
--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -47,7 +47,6 @@
     <PackageReference Include="Sylvan.Common" Version="0.4.2" />
     <PackageReference Include="Sylvan.Data.Csv" Version="1.3.3" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" NoWarn="NU1608" />
-    <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
     <PackageReference Include="TinyCsvParser" Version="2.7.0" />
     <PackageReference Include="TxtCsvHelper" Version="1.3.3" />
   </ItemGroup>


### PR DESCRIPTION
I was reading the last post on blog and notice that I forget to remove the `System.IO.Pipelines` nuget dependecy. It was necessary for early versions of `RecordParser` but once I added in the lib the ability to reads files by its own we do not need it any more.

btw, @joelverhagen cloud you please remove this information from the section "CSV libraries tested" ?

![image](https://github.com/joelverhagen/NCsvPerf/assets/11452028/00afab0f-c480-48b2-a9e1-9f244b35fece)
