### PR TITLE
Sep 0.4.0

### DIFF
--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -242,6 +242,12 @@ namespace Knapcode.NCsvPerf.CsvReadable.TestCases
         }
 
         [Benchmark]
+        public void Sep_MT()
+        {
+            Execute(new Sep_MT());
+        }
+
+        [Benchmark]
         public void ServiceStack_Text()
         {
             Execute(new ServiceStack_Text());

--- a/NCsvPerf/CsvReadable/Implementations/Sep_MT.cs
+++ b/NCsvPerf/CsvReadable/Implementations/Sep_MT.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using nietras.SeparatedValues;
+
+namespace Knapcode.NCsvPerf.CsvReadable
+{
+    public class Sep_MT : ICsvReader
+    {
+        public List<T> GetRecords<T>(MemoryStream stream) where T : ICsvReadable, new()
+        {
+            using var reader = nietras.SeparatedValues.Sep.Reader(o => o with
+            {
+                HasHeader = false,
+#if ENABLE_STRING_POOLING
+                CreateToString = SepToString.PoolPerColThreadSafeFixedCapacity(maximumStringLength: 128),
+#endif
+            })
+            .From(stream);
+
+            return reader.ParallelEnumerate(row =>
+            {
+                var record = new T();
+                record.Read(row.UnsafeToStringDelegate);
+                return record;
+            }).ToList();
+        }
+    }
+}

--- a/NCsvPerf/NCsvPerf.csproj
+++ b/NCsvPerf/NCsvPerf.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="NReco.Csv" Version="1.0.2" />
     <PackageReference Include="Open.Text.CSV" Version="3.4.0" />
     <PackageReference Include="RecordParser" Version="2.1.0" />
-    <PackageReference Include="Sep" Version="0.2.7" />
+    <PackageReference Include="Sep" Version="0.4.0" />
     <PackageReference Include="ServiceStack.Text" Version="6.11.0" />
     <PackageReference Include="Sky.Data.Csv" Version="2.5.0" />
     <PackageReference Include="SoftCircuits.CsvParser" Version="4.1.0" />

--- a/NCsvPerf/Program.cs
+++ b/NCsvPerf/Program.cs
@@ -14,7 +14,7 @@ namespace Knapcode.NCsvPerf
 #else
             config = null;
 #endif
-            BenchmarkRunner.Run<PackageAssetsSuite>(config);
+            BenchmarkRunner.Run<PackageAssetsSuite>(config, args);
         }
     }
 }


### PR DESCRIPTION
@joelverhagen use new Sep with new multi-threaded parsing. I believe this warrants an update to your blog 😉 If you don't have time or won't be updating for a while, maybe if okay with you I will do an update on my blog (besides hopefully an upcoming blog post on 0.4.0 release).

Should we switch to .NET 8 while we are at it?

Additionally, this benchmark is now very much GC constrained, so try switching to server GC too (as also mentioned in #9), results can be seen in https://github.com/nietras/Sep benchmarks. It's significantly faster.