### PR TITLE
Add bench.ps1 and customize run and exporters

### DIFF
--- a/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
+++ b/NCsvPerf/CsvReadable/Benchmarks/PackageAssetsSuite.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
 
 namespace Knapcode.NCsvPerf.CsvReadable.TestCases
 {
     [MemoryDiagnoser]
-    [SimpleJob(1, 2, 6, 1)]
+    [Orderer(SummaryOrderPolicy.FastestToSlowest)]
     public class PackageAssetsSuite
     {
         private byte[] _bytes;

--- a/NCsvPerf/Program.cs
+++ b/NCsvPerf/Program.cs
@@ -1,4 +1,9 @@
-﻿using BenchmarkDotNet.Configs;
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using Knapcode.NCsvPerf.CsvReadable.TestCases;
 
@@ -8,11 +13,27 @@ namespace Knapcode.NCsvPerf
     {
         private static void Main(string[] args)
         {
-            IConfig config = null;
 #if DEBUG
-            config = new DebugInProcessConfig();
+            var config = new DebugInProcessConfig();
 #else
-            config = null;
+            // Remove time units from column values for csv exporter as per:
+            // https://github.com/dotnet/BenchmarkDotNet/issues/1207
+            var csvExporter = new CsvExporter(
+                CsvSeparator.CurrentCulture,
+                new SummaryStyle(
+                    cultureInfo: System.Globalization.CultureInfo.InvariantCulture,
+                    printUnitsInHeader: true,
+                    printUnitsInContent: false,
+                    timeUnit: Perfolizer.Horology.TimeUnit.Millisecond,
+                    sizeUnit: SizeUnit.KB
+                ));
+            var config = ManualConfig
+                .CreateEmpty()
+                .AddColumnProvider(DefaultColumnProviders.Instance)
+                .AddLogger(ConsoleLogger.Default)
+                .AddExporter(csvExporter)
+                .AddExporter(HtmlExporter.Default)
+                .AddExporter(MarkdownExporter.GitHub);
 #endif
             BenchmarkRunner.Run<PackageAssetsSuite>(config, args);
         }

--- a/bench.ps1
+++ b/bench.ps1
@@ -1,3 +1,3 @@
 #!/usr/bin/env pwsh
 # Add `--filter *.METHOD*` or similar to run subset of benchmarks
-dotnet run -c Release --project NCsvPerf\NCsvPerf.csproj -- -m --minWarmupCount 3 --maxWarmupCount 5 --minIterationCount 5 --maxIterationCount 11 --filter *.Sep*
+dotnet run -c Release --project NCsvPerf\NCsvPerf.csproj -- -m --minWarmupCount 3 --maxWarmupCount 5 --minIterationCount 5 --maxIterationCount 11

--- a/bench.ps1
+++ b/bench.ps1
@@ -1,0 +1,3 @@
+#!/usr/bin/env pwsh
+# Add `--filter *.METHOD*` or similar to run subset of benchmarks
+dotnet run -c Release --project NCsvPerf\NCsvPerf.csproj -- -m --minWarmupCount 3 --maxWarmupCount 5 --minIterationCount 5 --maxIterationCount 11 --filter *.Sep*


### PR DESCRIPTION
@joelverhagen a few proposed changes to benchmark running now that args are forwarded. I do not know if you prefer the old way if so I can change to whatever you prefer. This change means csv file output is more directly usable e.g. in Excel. As output is sorted and units only defined in column names.

Changed run parameters since Sep and others are quite fast now and below 200 ms for a run, this can be tweaked to whatever you like. Currently, show casing how one can filter and only run Sep methods by `--filter *.Sep*` allowing for incremental updates.

```
Method,Job,AnalyzeLaunchVariance,EvaluateOverhead,MaxAbsoluteError,MaxRelativeError,MinInvokeCount,MinIterationTime,OutlierMode,Affinity,EnvironmentVariables,Jit,LargeAddressAware,Platform,PowerPlanMode,Runtime,AllowVeryLargeObjects,Concurrent,CpuGroups,Force,HeapAffinitizeMask,HeapCount,NoAffinitize,RetainVm,Server,Arguments,BuildConfiguration,Clock,EngineFactory,NuGetReferences,Toolchain,IsMutator,InvocationCount,IterationCount,IterationTime,LaunchCount,MaxIterationCount,MaxWarmupIterationCount,MemoryRandomization,MinIterationCount,MinWarmupIterationCount,RunStrategy,UnrollFactor,WarmupCount,LineCount,Mean [ms],Error [ms],StdDev [ms],Gen0,Gen1,Gen2,Allocated [KB]
Sep_MT,Job-LGJPSJ,False,Default,Default,Default,Default,Default,Default,11111111111111111111111111111111,Empty,RyuJit,Default,X64,8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c,.NET 8.0,False,True,False,True,Default,Default,False,False,False,Default,Default,Default,Default,Default,Default,Default,Default,Default,Default,Default,11,5,Default,5,3,Default,16,Default,1000000,309.0,35.37,25.58,16000.0000,15000.0000,1000.0000,268686.44
Sep,Job-LGJPSJ,False,Default,Default,Default,Default,Default,Default,11111111111111111111111111111111,Empty,RyuJit,Default,X64,8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c,.NET 8.0,False,True,False,True,Default,Default,False,False,False,Default,Default,Default,Default,Default,Default,Default,Default,Default,Default,Default,11,5,Default,5,3,Default,16,Default,1000000,682.5,24.98,18.06,18000.0000,17000.0000,3000.0000,266674.98
```

Example console output
![image](https://github.com/joelverhagen/NCsvPerf/assets/10798831/b43155ba-81be-4a07-8d02-4d5d867e2e6d)
