### PR TITLE
Tweak bench.ps1

### DIFF
--- a/bench.ps1
+++ b/bench.ps1
@@ -1,3 +1,3 @@
 #!/usr/bin/env pwsh
 # Add `--filter *.METHOD*` or similar to run subset of benchmarks
-dotnet run -c Release --project NCsvPerf\NCsvPerf.csproj -- -m --minWarmupCount 3 --maxWarmupCount 5 --minIterationCount 5 --maxIterationCount 11
+dotnet run -c Release --project NCsvPerf\NCsvPerf.csproj -- -m --warmupCount 1 --minIterationCount 2 --maxIterationCount 5 --iterationTime 2000


### PR DESCRIPTION
@joelverhagen using `iterationTime` to ensure fast impls get more "iterations" while keep iterations low for slow. I hope this means this is as fast as before and still reliable. Running this now locally, so will see how it looks soon.

Results on my machine are not exactly reproducible/reliable for this long running benchmarking. If running Sep only I get:
![image](https://github.com/joelverhagen/NCsvPerf/assets/10798831/3f73849b-68b6-44f6-bd1c-9700f0403b34)
If running all:
![image](https://github.com/joelverhagen/NCsvPerf/assets/10798831/3c57bb63-452e-4c34-9916-c3d78762b4a9)

Note how `Sep` (single-threaded) is noticably slower when running all, maybe due to thermal throttling. Not sure. Do not think this is due to BDN params.

Sep is `21289/382 = 55x` faster than the slowest one.